### PR TITLE
Add start_maximized configuration and --maximized flag

### DIFF
--- a/src/config_manager.vala
+++ b/src/config_manager.vala
@@ -9,6 +9,7 @@ public class ConfigManager {
     public double opacity { get; private set; }
     public string font { get; private set; }
     public int font_size { get; private set; }
+    public bool start_maximized { get; private set; }
 
     // Shortcut mappings
     private HashTable<string, string> shortcuts;
@@ -90,12 +91,19 @@ public class ConfigManager {
                 opacity = config_file.get_double("general", "opacity");
                 font = config_file.get_string("general", "font");
                 font_size = config_file.get_integer("general", "font_size");
+                // Load start_maximized with default false if not present
+                try {
+                    start_maximized = config_file.get_boolean("general", "start_maximized");
+                } catch (KeyFileError e) {
+                    start_maximized = false;
+                }
             } else {
                 // Set defaults if general section is missing
                 theme = "default";
                 opacity = 0.88;
                 font = "Hack";
                 font_size = 13;
+                start_maximized = false;
             }
 
             // Load shortcuts
@@ -113,6 +121,7 @@ public class ConfigManager {
             opacity = 0.88;
             font = "Hack";
             font_size = 13;
+            start_maximized = false;
         }
     }
 
@@ -146,6 +155,12 @@ public class ConfigManager {
         save_config();
     }
 
+    // Update start_maximized setting and save to config file
+    public void update_start_maximized(bool new_start_maximized) {
+        start_maximized = new_start_maximized;
+        save_config();
+    }
+
     // Save current configuration to file
     private void save_config() {
         try {
@@ -155,6 +170,7 @@ public class ConfigManager {
             config_file.set_string("general", "opacity", "%.2f".printf(opacity));
             config_file.set_string("general", "font", font);
             config_file.set_integer("general", "font_size", font_size);
+            config_file.set_boolean("general", "start_maximized", start_maximized);
 
             // Save to file
             string data = config_file.to_data();

--- a/src/main.vala
+++ b/src/main.vala
@@ -3,6 +3,7 @@
 public class LazyCatTerminal : Gtk.Application {
     public static string[] launch_commands = {};
     public static string? working_directory = null;
+    public static bool start_maximized = false;
 
     public LazyCatTerminal() {
         Object(
@@ -38,6 +39,8 @@ public class LazyCatTerminal : Gtk.Application {
                 next_is_directory = true;
             } else if (args[i] == "--execute" || args[i] == "-e") {
                 next_is_execute = true;
+            } else if (args[i] == "--maximized" || args[i] == "-m") {
+                start_maximized = true;
             }
         }
 

--- a/src/window.vala
+++ b/src/window.vala
@@ -38,6 +38,11 @@ public class TerminalWindow : ShadowWindow {
         add_new_tab();
         setup_snap_detection();
         setup_close_handler();
+
+        // Maximize window if configured or requested via command line
+        if (config.start_maximized || LazyCatTerminal.start_maximized) {
+            maximize();
+        }
     }
 
     private void setup_window() {


### PR DESCRIPTION
## Summary
- Add `start_maximized` config option to start window maximized
- Add `--maximized` / `-m` command line flag
- Follows the pattern used by Kitty terminal (both config and CLI)

## Usage

**Config file:**
```ini
[general]
start_maximized=true
```

**Command line:**
```bash
lazycat-terminal --maximized
lazycat-terminal -m
```

## Test plan
- [x] Set `start_maximized=true` in config, verify window starts maximized
- [x] Run with `--maximized` flag, verify window starts maximized
- [x] Run without flag and config, verify window starts normal