### PR TITLE
add aur publish github action

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -1,0 +1,35 @@
+name: Publish to AUR
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish-aur:
+    name: Publish to AUR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract version
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Update PKGBUILD version
+        run: |
+          sed -i "s/^pkgver=.*/pkgver=${{ steps.version.outputs.version }}/" PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+
+      - name: Publish AUR package
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
+        with:
+          pkgname: lazycat-terminal
+          pkgbuild: ./PKGBUILD
+          updpkgsums: true
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "Update to version ${{ steps.version.outputs.version }}"
+          ssh_keyscan_types: rsa,ecdsa,ed25519


### PR DESCRIPTION
这个 workflow 会在以下情况触发：
  - 推送以 v 开头的 tag 时（例如 v0.1.4）

  主要功能：
  1. 自动从 tag 提取版本号
  2. 更新 PKGBUILD 中的 pkgver 和 pkgrel
  3. 使用 updpkgsums 自动更新 sha256 校验和
  4. 发布到 AUR 仓库

  需要在 GitHub 仓库设置中配置以下 Secrets：
  - AUR_USERNAME - 你的 AUR 用户名
  - AUR_EMAIL - 你的 AUR 邮箱
  - AUR_SSH_PRIVATE_KEY - 你的 AUR SSH 私钥