### PR TITLE
feat: 支持 Ctrl+Shift+B 随机切换背景图片

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Note: `Return` refers to the Enter key on the main keyboard; `Enter` refers to t
 | `F11` | Toggle fullscreen mode |
 | `Ctrl+Scroll` | Adjust window transparency |
 | `Ctrl+Shift+E` | Open settings dialog |
+| `Ctrl+Shift+B` | Randomly switch background image (directory mode) |
 | `Ctrl+Click link` | Open URL in browser |
 
 ### Mouse Operations
@@ -190,6 +191,7 @@ Available modifiers: `Ctrl`, `Shift`, `Alt`, `Super`
 
 **Other:**
 - `fullscreen` - Toggle fullscreen mode (default: `F11`)
+- `switch_background` - Randomly switch background image (default: `Ctrl + Shift + b`), only works when background image is set to a directory
 
 **Example Configuration:**
 
@@ -215,6 +217,7 @@ switch_to_workspace_2=Alt + 2
 # ...
 switch_to_last_workspace=Alt + 0
 # ... other shortcuts ...
+switch_background=Ctrl + Shift + b
 ```
 
 **Background Image Examples:**
@@ -225,6 +228,7 @@ background_image=~/Pictures/wallpaper.jpg
 
 # Random image from directory (picks one on each launch)
 background_image=~/Pictures/terminal-backgrounds/
+# Press Ctrl+Shift+B to randomly switch to another image from the directory at runtime
 ```
 
 ### Development

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,6 +99,7 @@ yay -S lazycat-terminal
 | `F11` | 切换全屏模式 |
 | `Ctrl+滚轮` | 调节窗口透明度 |
 | `Ctrl+Shift+E` | 打开设置对话框 |
+| `Ctrl+Shift+B` | 随机切换背景图片（目录模式） |
 | `Ctrl+点击链接` | 在浏览器中打开 URL |
 
 ### 鼠标操作
@@ -190,6 +191,7 @@ lazycat-terminal [选项]
 
 **其他：**
 - `fullscreen` - 切换全屏模式（默认：`F11`）
+- `switch_background` - 随机切换背景图片（默认：`Ctrl + Shift + b`），仅在背景图片为目录模式时生效
 
 **配置示例：**
 
@@ -215,6 +217,7 @@ switch_to_workspace_2=Alt + 2
 # ...
 switch_to_last_workspace=Alt + 0
 # ... 其他快捷键 ...
+switch_background=Ctrl + Shift + b
 ```
 
 **背景图片配置示例：**
@@ -225,6 +228,7 @@ background_image=~/Pictures/wallpaper.jpg
 
 # 随机背景（每次启动从目录中随机选取一张）
 background_image=~/Pictures/terminal-backgrounds/
+# 使用 Ctrl+Shift+B 可以在运行时随机切换到目录中的另一张图片
 ```
 
 ### 源码开发

--- a/config.conf
+++ b/config.conf
@@ -46,3 +46,4 @@ select_right_window=Alt + l
 close_window=Ctrl + Alt + q
 close_other_windows=Ctrl + Shift + q
 copy_last_output=Ctrl + Alt + c
+switch_background=Ctrl + Shift + b

--- a/src/window.vala
+++ b/src/window.vala
@@ -16,6 +16,8 @@ public class TerminalWindow : ShadowWindow {
     private ContextMenuOverlay? context_menu = null;
     private ConfigManager config;
     private Gtk.Picture? background_picture = null;
+    private string? current_background_path = null;
+    private File? background_dir = null;
 
     public TerminalWindow(Gtk.Application app) {
         Object(application: app);
@@ -619,6 +621,13 @@ public class TerminalWindow : ShadowWindow {
                     var tab = tabs.nth_data((uint)tab_bar.get_active_index());
                     if (tab != null) tab.close_other_terminals();
                 }
+                return true;
+            }
+
+            // Switch background image
+            string? switch_bg_shortcut = config.get_shortcut("switch_background");
+            if (switch_bg_shortcut != null && key_name == switch_bg_shortcut) {
+                switch_background_image();
                 return true;
             }
 
@@ -1646,7 +1655,8 @@ public class TerminalWindow : ShadowWindow {
         try {
             var info = file.query_info(FileAttribute.STANDARD_TYPE, FileQueryInfoFlags.NONE);
             if (info.get_file_type() == FileType.DIRECTORY) {
-                file = pick_random_image(file);
+                background_dir = file;
+                file = pick_random_image(file, null);
                 if (file == null) {
                     stderr.printf("No images found in directory: %s\n", image_path);
                     return;
@@ -1657,6 +1667,7 @@ public class TerminalWindow : ShadowWindow {
             return;
         }
 
+        current_background_path = file.get_path();
         background_picture = new Gtk.Picture.for_file(file);
         background_picture.set_content_fit(Gtk.ContentFit.COVER);
         background_picture.set_can_shrink(true);
@@ -1664,7 +1675,7 @@ public class TerminalWindow : ShadowWindow {
         background_picture.set_vexpand(true);
     }
 
-    private File? pick_random_image(File dir) {
+    private File? pick_random_image(File dir, string? exclude_path) {
         var images = new GenericArray<File>();
         try {
             var enumerator = dir.enumerate_children(
@@ -1680,7 +1691,10 @@ public class TerminalWindow : ShadowWindow {
                 if (name.has_suffix(".jpg") || name.has_suffix(".jpeg") ||
                     name.has_suffix(".png") || name.has_suffix(".webp") ||
                     name.has_suffix(".bmp")) {
-                    images.add(dir.get_child(child_info.get_name()));
+                    var child = dir.get_child(child_info.get_name());
+                    if (exclude_path == null || child.get_path() != exclude_path) {
+                        images.add(child);
+                    }
                 }
             }
         } catch (Error e) {
@@ -1694,5 +1708,17 @@ public class TerminalWindow : ShadowWindow {
 
         int index = Random.int_range(0, (int32)images.length);
         return images[index];
+    }
+
+    private void switch_background_image() {
+        if (background_dir == null || background_picture == null) {
+            return;
+        }
+
+        var new_image = pick_random_image(background_dir, current_background_path);
+        if (new_image != null) {
+            current_background_path = new_image.get_path();
+            background_picture.set_file(new_image);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #18

- 新增快捷键 `Ctrl+Shift+B`，在背景图片目录模式下随机切换背景图片
- 切换时自动排除当前图片，保证每次都是不同的壁纸
- 记录当前背景图片路径和目录引用，支持运行时动态切换

## 改动文件

- `config.conf`: 新增 `switch_background` 快捷键配置
- `src/window.vala`: 添加 `switch_background_image()` 方法和快捷键处理逻辑

## Test plan

- [ ] 配置背景图片为包含多张图片的目录
- [ ] 按 `Ctrl+Shift+B` 验证背景图片随机切换
- [ ] 验证切换后图片与之前不同
- [ ] 配置背景图片为单张图片时，按快捷键无反应（符合预期）